### PR TITLE
Properly propagate new tag to git push command.

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,12 +25,14 @@ jobs:
             fetch-depth: '0'
 
       - name: Add new tag on git
+        id: tag
         run: |
           NEW_TAG=$(grep 'ROUTEROS_VERSION="' Dockerfile |cut -d '"' -f 2)
           git config user.name 'GitHub Actions'
           git config user.email 'github-actions@users.noreply.github.com'
           git tag "$NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Push new tag to git
         if: ${{ !env.ACT }}
-        run: git push origin "$NEW_TAG"
+        run: git push origin ${{ steps.tag.outputs.new_tag }}


### PR DESCRIPTION
Sorry about this little miss. As always, things that are not tested should be assumed to be broken. Hopefully this goes through all the way to docker hub.