### PR TITLE
Apparently, it should be single quote for star matching.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "*"
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
It should still be possible to trigger this action by pushing tag for the following commit:
- 2a375306560f0a817007a43160b391b6462abd62 7.13.2
- a3e85227bd5348107eb5012a5e9dc8ee57ead189 6.49.12

It should also be possible to manually trigger it for master which should push latest and 7.13.4.

This will require the secret DOCKERHUB_USERNAME and DOCKERHUB_TOKEN to have been set on this repository to work. Hopefully with this change everything is properly automated.